### PR TITLE
Fix multi-camera action conditioning layout

### DIFF
--- a/prismatic/models/action_heads.py
+++ b/prismatic/models/action_heads.py
@@ -17,6 +17,21 @@ def learnable_random_perturbations(seq_len, dim, device, dtype):
     return random_perturbations
 
 
+def split_task_action_hidden_states(hidden_states, num_action_tokens=NUM_TOKENS):
+    """Split `[task tokens, action tokens]` using the fixed trailing action-token count."""
+    if hidden_states.ndim != 4:
+        raise ValueError(f"Expected hidden states with 4 dimensions, got shape {tuple(hidden_states.shape)}")
+    if num_action_tokens <= 0:
+        raise ValueError(f"num_action_tokens must be positive, got {num_action_tokens}")
+    if hidden_states.shape[2] <= num_action_tokens:
+        raise ValueError(
+            f"Token count {hidden_states.shape[2]} must exceed the {num_action_tokens} trailing action tokens"
+        )
+
+    task_end = hidden_states.shape[2] - num_action_tokens
+    return hidden_states[:, :, :task_end, :], hidden_states[:, :, task_end:, :]
+
+
 
 class L1RegressionActionHead(nn.Module):
     """Simple MLP-based action head that generates continuous actions via L1 regression."""
@@ -29,6 +44,7 @@ class L1RegressionActionHead(nn.Module):
         use_pro_version=False,
     ):
         super().__init__()
+        # Retain this attribute for constructor compatibility; the runtime boundary is inferred below.
         self.num_task_tokens = num_task_tokens
         self.action_dim = action_dim
         self.hidden_dim = hidden_dim
@@ -54,8 +70,7 @@ class L1RegressionActionHead(nn.Module):
         proprio_features = proprio_projector(proprio)  # (bsz, llm_dim)
         proprio_features = proprio_features.unsqueeze(dim=1)  # (bsz, 1, llm_dim)
 
-        task_hidden_states = actions_hidden_states[:, :, :self.num_task_tokens, :]
-        actions_hidden_states = actions_hidden_states[:, :, self.num_task_tokens:, :]
+        task_hidden_states, actions_hidden_states = split_task_action_hidden_states(actions_hidden_states)
 
         cond_actions_hidden_states = torch.zeros(
             (batch_size, self.action_dim * NUM_ACTIONS_CHUNK, self.hidden_dim),

--- a/tests/test_action_head_token_layout.py
+++ b/tests/test_action_head_token_layout.py
@@ -1,0 +1,91 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_action_heads_module():
+    constants = types.ModuleType("prismatic.vla.constants")
+    constants.ACTION_DIM = 7
+    constants.ACTION_TOKEN_BEGIN_IDX = 0
+    constants.IGNORE_INDEX = -100
+    constants.NUM_ACTIONS_CHUNK = 8
+    constants.PROPRIO_DIM = 8
+    constants.STOP_INDEX = 0
+    constants.NUM_TOKENS = 64
+
+    module_path = Path(__file__).parents[1] / "prismatic" / "models" / "action_heads.py"
+    spec = importlib.util.spec_from_file_location("action_heads_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    previous_constants = sys.modules.get(constants.__name__)
+    try:
+        sys.modules[constants.__name__] = constants
+        spec.loader.exec_module(module)
+    finally:
+        if previous_constants is None:
+            sys.modules.pop(constants.__name__, None)
+        else:
+            sys.modules[constants.__name__] = previous_constants
+    return module
+
+
+action_heads = _load_action_heads_module()
+
+
+@pytest.mark.parametrize("num_images", [1, 2, 3])
+def test_split_preserves_all_camera_and_action_tokens(num_images):
+    num_task_tokens = 256 * num_images
+    task = torch.arange(num_task_tokens).reshape(1, 1, num_task_tokens, 1)
+    actions = torch.arange(64).reshape(1, 1, 64, 1) + 10_000
+    hidden_states = torch.cat((task, actions), dim=2)
+
+    actual_task, actual_actions = action_heads.split_task_action_hidden_states(hidden_states)
+
+    torch.testing.assert_close(actual_task, task)
+    torch.testing.assert_close(actual_actions, actions)
+
+
+@pytest.mark.parametrize("num_images", [1, 3])
+def test_action_head_conditions_on_every_camera_and_exactly_64_action_tokens(num_images):
+    class CaptureConditioning(torch.nn.Module):
+        def forward(self, x, h_a, p, h_t):
+            self.task = h_t
+            self.actions = h_a
+            return torch.zeros(x.shape[0], x.shape[1], 7)
+
+    num_task_tokens = 256 * num_images
+    task = torch.randn(1, 2, num_task_tokens, 8)
+    actions = torch.randn(1, 2, 64, 8)
+    head = action_heads.L1RegressionActionHead(input_dim=8, hidden_dim=8)
+    head.model = CaptureConditioning()
+
+    head.predict_action(
+        torch.cat((task, actions), dim=2),
+        proprio=torch.zeros(1, 8),
+        proprio_projector=torch.nn.Identity(),
+    )
+
+    torch.testing.assert_close(head.model.task, task)
+    torch.testing.assert_close(head.model.actions, actions)
+
+
+@pytest.mark.parametrize(
+    ("hidden_states", "num_action_tokens"),
+    [(torch.empty(1, 2, 64, 4), 64), (torch.empty(1, 2, 63, 4), 64)],
+)
+def test_split_rejects_sequences_without_task_tokens(hidden_states, num_action_tokens):
+    with pytest.raises(ValueError, match="must exceed"):
+        action_heads.split_task_action_hidden_states(hidden_states, num_action_tokens)
+
+
+def test_dynamic_split_keeps_legacy_action_head_state_dict_compatible():
+    legacy_head = action_heads.L1RegressionActionHead(input_dim=8, hidden_dim=8, num_task_tokens=512)
+    dynamic_head = action_heads.L1RegressionActionHead(input_dim=8, hidden_dim=8)
+
+    incompatible_keys = dynamic_head.load_state_dict(legacy_head.state_dict(), strict=True)
+
+    assert incompatible_keys.missing_keys == []
+    assert incompatible_keys.unexpected_keys == []


### PR DESCRIPTION
## Summary

- derive the action-head split from the fixed trailing 64 action-conditioning tokens instead of a hard-coded 512 task-token boundary
- preserve the existing constructor and state-dict layout
- cover one-, two-, and three-camera conditioning, including the full action-head call path

## Why

Training and inference assemble the action-head input as P visual task tokens followed by NUM_TOKENS=64 action predictor states. P depends on the configured number of cameras: the standard 256-patch backbone produces 256, 512, or 768 task tokens for one, two, or three images.

L1RegressionActionHead nevertheless always split at num_task_tokens=512. With one image, all 320 input tokens were classified as task tokens and the action-conditioning branch was empty. With three images, the final 256 visual patches were classified as action tokens, producing a 320-token action branch. Only the two-camera case happened to match the constant.

Since the action suffix has an explicit fixed-size contract throughout the data and model paths, splitting from the tail preserves every camera token and exactly 64 action tokens for each supported layout. The two-camera behavior is unchanged, and no parameter or buffer shape changes.

This PR intentionally leaves the separate BOS/EOS hidden-state indexing work in #24 untouched.

## Validation

- python -m pytest -q tests/test_action_head_token_layout.py (8 passed)
- direct action-head conditioning checks for one and three cameras
- strict state-dict loading compatibility check
- py_compile, Ruff, and git diff --check