### PR TITLE
Fix distributed modality batching for small splits

### DIFF
--- a/prismatic/util/batching_utils.py
+++ b/prismatic/util/batching_utils.py
@@ -42,7 +42,28 @@ class SplitModalitySampler(Sampler):
 
         # For our purposes, `drop_last` is always False!
         assert not self.drop_last, "SplitModalitySampler must set `drop_last = False`!"
-        self.total_size = math.ceil(len(self.dataset) / self.global_batch_size) * self.global_batch_size
+        if len(self.dataset) == 0:
+            raise ValueError("SplitModalitySampler requires a non-empty dataset")
+        if len(self.modality_lengths) != len(self.dataset):
+            raise ValueError("modality_lengths must contain one entry per dataset item")
+        if self.global_batch_size <= 0:
+            raise ValueError("global_batch_size must be positive")
+        if self.num_replicas <= 0:
+            raise ValueError("num_replicas must be positive")
+        if self.global_batch_size % self.num_replicas != 0:
+            raise ValueError("global_batch_size must be divisible by num_replicas")
+
+        # Each modality is batched independently so that every global batch is
+        # homogeneous.  Consequently, two modality tails may require more
+        # padding than ceil(len(dataset) / global_batch_size) would provide.
+        modality_counts = [
+            sum(1 for is_multimodal, _ in self.modality_lengths if is_multimodal),
+            sum(1 for is_multimodal, _ in self.modality_lengths if not is_multimodal),
+        ]
+        num_batches = sum(
+            math.ceil(count / self.global_batch_size) for count in modality_counts if count > 0
+        )
+        self.total_size = num_batches * self.global_batch_size
         self.num_samples = self.total_size // self.num_replicas
 
     @staticmethod
@@ -73,42 +94,46 @@ class SplitModalitySampler(Sampler):
         of the same modality with each sub-sequence of `per_replica_batch_size` (the batch size each unique device sees
         during distributed training) is roughly grouped by sequence length (for training efficiency).
         """
-        multimodal_indices, multimodal_lengths = zip(
-            *[(idx, length) for idx, (is_multimodal, length) in enumerate(self.modality_lengths) if is_multimodal]
-        )
-
-        # Handle Special Case --> no "unimodal" inputs
+        multimodal_split = [
+            (idx, length) for idx, (is_multimodal, length) in enumerate(self.modality_lengths) if is_multimodal
+        ]
         unimodal_split = [
             (idx, length) for idx, (is_multimodal, length) in enumerate(self.modality_lengths) if not is_multimodal
         ]
-        if len(unimodal_split) == 0:
-            unimodal_indices, unimodal_lengths = [], []
+        if multimodal_split:
+            multimodal_indices, multimodal_lengths = map(list, zip(*multimodal_split))
         else:
-            unimodal_indices, unimodal_lengths = zip(*unimodal_split)
-
-        # Create a permutation of indices for each of the multimodal and unimodal data
-        mm_shuffled_idxs = torch.randperm(len(multimodal_indices), generator=generator)
-        uni_shuffled_idxs = torch.randperm(len(unimodal_indices), generator=generator)
+            multimodal_indices, multimodal_lengths = [], []
+        if unimodal_split:
+            unimodal_indices, unimodal_lengths = map(list, zip(*unimodal_split))
+        else:
+            unimodal_indices, unimodal_lengths = [], []
 
         # We're going to be running sorting/grouping relative to `self.global_batch_size` and `self.num_replicas`
         g_bsz = self.global_batch_size
 
-        # Break each of the permutations into batches of length `global_batch_size`
-        mm_batch_idxs = [mm_shuffled_idxs[i : i + g_bsz].tolist() for i in range(0, len(mm_shuffled_idxs), g_bsz)]
-        uni_batch_idxs = [uni_shuffled_idxs[i : i + g_bsz].tolist() for i in range(0, len(uni_shuffled_idxs), g_bsz)]
+        def make_batches(indices: List[int], lengths: List[int]) -> List[List[int]]:
+            """Shuffle, pad, and distribute one modality without empty-tail failures."""
+            if not indices:
+                return []
 
-        # If "last" batch is not of length `g_bsz` --> PAD by stealing indices from the first batch!
-        if len(mm_batch_idxs[-1]) < g_bsz:
-            n_missing = g_bsz - len(mm_batch_idxs[-1])
-            mm_batch_idxs[-1].extend(mm_batch_idxs[0][:n_missing])
+            shuffled_idxs = torch.randperm(len(indices), generator=generator).tolist()
+            batch_idxs = [shuffled_idxs[i : i + g_bsz] for i in range(0, len(shuffled_idxs), g_bsz)]
 
-        if len(uni_batch_idxs) > 0 and len(uni_batch_idxs[-1]) < g_bsz:
-            n_missing = g_bsz - len(uni_batch_idxs[-1])
-            uni_batch_idxs[-1].extend(uni_batch_idxs[0][:n_missing])
+            # Pad a short tail cyclically.  A modality can contain fewer than
+            # one global batch, so slicing the first batch once is insufficient.
+            if len(batch_idxs[-1]) < g_bsz:
+                n_missing = g_bsz - len(batch_idxs[-1])
+                first_batch = batch_idxs[0]
+                batch_idxs[-1].extend(first_batch[i % len(first_batch)] for i in range(n_missing))
 
-        # Now we're going to sort each batch by length --> this will aid in grouping by length by rank (efficiency!)
-        mm_sorted_batch_idxs = [sorted(b, key=lambda i: multimodal_lengths[i], reverse=True) for b in mm_batch_idxs]
-        uni_sorted_batch_idxs = [sorted(b, key=lambda i: unimodal_lengths[i], reverse=True) for b in uni_batch_idxs]
+            sorted_batch_idxs = [sorted(batch, key=lambda i: lengths[i], reverse=True) for batch in batch_idxs]
+            length_bucketed_idxs = [
+                self.reindex_batch(batch, lengths, self.num_replicas) for batch in sorted_batch_idxs
+            ]
+            output_idxs = [idx for batch in length_bucketed_idxs for bucket in batch for idx in bucket]
+            reindexed = [indices[idx] for idx in output_idxs]
+            return [reindexed[i : i + g_bsz] for i in range(0, len(reindexed), g_bsz)]
 
         # IMPORTANT :: At this point, for each modality, we have a list of "batches" (made up of indices) where indices
         # are sorted by example sequence length *within* each batch. To make this more concrete, consider the following:
@@ -147,22 +172,8 @@ class SplitModalitySampler(Sampler):
         #   => `rank_1_indices`: [ [5 (18), 0 (20)] =>> [11 (17), 7 (19)] =>> [2 (21),  1 (90)] ]
         #
         # Much better! As `g_bsz` and `dataset` grow, we're more often than not getting *decent* groupings!
-        mm_length_bucketed_idxs = [
-            self.reindex_batch(batch, multimodal_lengths, self.num_replicas) for batch in mm_sorted_batch_idxs
-        ]
-        uni_length_bucketed_idxs = [
-            self.reindex_batch(batch, unimodal_lengths, self.num_replicas) for batch in uni_sorted_batch_idxs
-        ]
-
-        # Note :: Because of the initial `randperm` --> we're indexing both sets from 0 (we're clobbering the range)
-        #   => Flatten indices --> index into original `{modality}_indices` then re-batch!
-        mm_output_idxs = [idx for batch in mm_length_bucketed_idxs for bucket in batch for idx in bucket]
-        mm_reindexed = [multimodal_indices[idx] for idx in mm_output_idxs]
-        mm_batches = [mm_reindexed[i : i + g_bsz] for i in range(0, len(mm_reindexed), g_bsz)]
-
-        uni_output_idxs = [idx for batch in uni_length_bucketed_idxs for bucket in batch for idx in bucket]
-        uni_reindexed = [unimodal_indices[idx] for idx in uni_output_idxs]
-        uni_batches = [uni_reindexed[i : i + g_bsz] for i in range(0, len(uni_reindexed), g_bsz)]
+        mm_batches = make_batches(multimodal_indices, multimodal_lengths)
+        uni_batches = make_batches(unimodal_indices, unimodal_lengths)
 
         # Finally, randomly permute the multimodal & unimodal batches, merging into a single stream of indices
         merged_batches = mm_batches + uni_batches

--- a/tests/test_batching_utils.py
+++ b/tests/test_batching_utils.py
@@ -1,0 +1,95 @@
+"""Regression tests for distributed split-modality batching."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+_MODULE_PATH = Path(__file__).parents[1] / "prismatic" / "util" / "batching_utils.py"
+_SPEC = importlib.util.spec_from_file_location("vla_adapter_batching_utils", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+SplitModalitySampler = _MODULE.SplitModalitySampler
+
+
+class _Dataset:
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+
+def _sampler(modality_lengths, *, rank=0, global_batch_size=4, num_replicas=2):
+    return SplitModalitySampler(
+        _Dataset(len(modality_lengths)),
+        modality_lengths,
+        global_batch_size=global_batch_size,
+        num_replicas=num_replicas,
+        rank=rank,
+        seed=17,
+    )
+
+
+def _global_indices(sampler):
+    generator = torch.Generator().manual_seed(sampler.seed + sampler.epoch)
+    return sampler.get_modality_and_length_grouped_indices(generator)
+
+
+def test_all_multimodal_split_handles_short_tail_and_distributes_every_item():
+    modality_lengths = [(True, 7), (True, 3), (True, 5)]
+    rank0 = _sampler(modality_lengths, rank=0)
+    rank1 = _sampler(modality_lengths, rank=1)
+
+    assert len(rank0) == len(rank1) == 2
+    assert set(iter(rank0)) | set(iter(rank1)) == {0, 1, 2}
+    assert len(rank0) == rank0.num_samples == 2
+    assert rank0.total_size == 4
+
+
+def test_all_unimodal_split_no_longer_crashes_on_empty_multimodal_partition():
+    modality_lengths = [(False, 8), (False, 2), (False, 6)]
+    sampler = _sampler(modality_lengths)
+
+    indices = _global_indices(sampler)
+    assert len(indices) == sampler.total_size == 4
+    assert set(indices) == {0, 1, 2}
+    assert len(list(iter(sampler))) == sampler.num_samples == 2
+
+
+def test_mixed_modalities_get_independent_full_batches_and_consistent_length():
+    modality_lengths = [(True, 9), (False, 4), (False, 2)]
+    sampler = _sampler(modality_lengths)
+    indices = _global_indices(sampler)
+
+    assert len(indices) == sampler.total_size == 8
+    for batch_start in range(0, len(indices), sampler.global_batch_size):
+        batch = indices[batch_start : batch_start + sampler.global_batch_size]
+        assert len({modality_lengths[idx][0] for idx in batch}) == 1
+    assert set(indices) == {0, 1, 2}
+    assert len(list(iter(sampler))) == sampler.num_samples == 4
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"global_batch_size": 0}, "global_batch_size"),
+        ({"global_batch_size": 3, "num_replicas": 2}, "divisible"),
+    ],
+)
+def test_invalid_batch_configuration_is_rejected(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        _sampler([(True, 1)], **kwargs)
+
+
+def test_metadata_must_match_dataset_length():
+    with pytest.raises(ValueError, match="one entry"):
+        SplitModalitySampler(_Dataset(2), [(True, 1)], global_batch_size=2, num_replicas=1, rank=0)
+
+
+def test_empty_dataset_is_rejected_before_sampling():
+    with pytest.raises(ValueError, match="non-empty"):
+        SplitModalitySampler(_Dataset(0), [], global_batch_size=2, num_replicas=1, rank=0)


### PR DESCRIPTION
## Summary
- make `SplitModalitySampler` safe when a dataset contains only one modality
- cyclically pad short modality partitions so every distributed global batch remains divisible by the replica count
- compute sampler length from independently padded modality batches
- add focused regression coverage for single-modality, mixed-modality, and invalid distributed configurations

## Why
The sampler always unpacked a multimodal partition, then indexed its last batch. A language-only or vision-only dataset therefore failed before the first training step. When both partitions were present but each was smaller than the global batch size, the old padding and `total_size` calculation could also produce undersized batches and inconsistent `__len__` values. This affects VLA fine-tuning runs that use filtered or highly imbalanced modality mixtures.

## Validation
- `python -m pytest -q tests/test_batching_utils.py` (7 passed)
- `python -m py_compile prismatic/util/batching_utils.py tests/test_batching_utils.py`
- `git diff --check`